### PR TITLE
version: 0.31.0 -> 0.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.32.0] - 2021-11-07
 ### Added
 - Added `Drop` for FTDI types that will call `close`.
 
@@ -137,7 +137,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Prior releases
 A changelog was not kept for prior releases.
 
-[Unreleased]: https://github.com/ftdi-rs/libftd2xx/compare/0.31.0...HEAD
+[Unreleased]: https://github.com/ftdi-rs/libftd2xx/compare/0.32.0...HEAD
+[0.32.0]: https://github.com/ftdi-rs/libftd2xx/compare/0.31.0...0.32.0
 [0.31.0]: https://github.com/ftdi-rs/libftd2xx/compare/0.30.0...0.31.0
 [0.30.0]: https://github.com/ftdi-rs/libftd2xx/compare/0.29.0...0.30.0
 [0.29.0]: https://github.com/ftdi-rs/libftd2xx/compare/0.28.0...0.29.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libftd2xx"
-version = "0.31.0" # remember to update html_root_url
+version = "0.32.0"
 authors = ["Alex Martens <alexmgit@protonmail.com>"]
 edition = "2018"
 description = "Rust safe wrapper around the libftd2xx-ffi crate."

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Simply add this crate as a dependency in your `Cargo.toml`.
 
 ```toml
 [dependencies.libftd2xx]
-version = "~0.31.0"
+version = "0.32"
 # statically link the vendor library, defaults to dynamic if not set
 # this will make things "just work" on Linux and Windows
 features = ["static"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! ```toml
 //! [dependencies.libftd2xx]
-//! version = "~0.31.0"
+//! version = "0.32"
 //! # statically link the vendor library, defaults to dynamic if not set
 //! # this will make things "just work" on Linux and Windows
 //! features = ["static"]
@@ -92,7 +92,6 @@
 //! [`ftd2xx-embedded-hal`]: https://crates.io/crates/ftd2xx-embedded-hal
 //! [`embedded-hal`]: https://crates.io/crates/embedded-hal
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![doc(html_root_url = "https://docs.rs/libftd2xx/0.31.0")]
 #![deny(missing_docs)]
 
 mod errors;


### PR DESCRIPTION
New release for  use in `ftdi-embedded-hal`.