### PR TITLE
Updated to the latest version of libftd2xx-ffi

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT"
 static = ["libftd2xx-ffi/static"]
 
 [dependencies]
-libftd2xx-ffi = "~0.8.3"
+libftd2xx-ffi = "~0.8.5"
 log = "~0.4.11"
 paste = "^1"
 static_assertions = "^1.1.0"


### PR DESCRIPTION
The underlying crate was updated after this discussion but it looks like this crate is still at the old version:
https://github.com/ftdi-rs/libftd2xx/issues/60#issuecomment-1250117632