### PR TITLE
Add support for 4232HA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Added support for the 4232HA
+
 ## [0.32.4] - 2024-03-04
 ### Added
 - Added EEPROM implementations for the 232R.

--- a/src/mpsse.rs
+++ b/src/mpsse.rs
@@ -30,7 +30,7 @@ fn clock_divisor(device: DeviceType, frequency: u32) -> (u32, Option<bool>) {
             check_limits(device, frequency, 6_000_000);
             (6_000_000 / frequency - 1, None)
         }
-        DeviceType::FT2232H | DeviceType::FT4232H | DeviceType::FT232H => {
+        DeviceType::FT2232H | DeviceType::FT4232H | DeviceType::FT4232HA | DeviceType::FT232H => {
             check_limits(device, frequency, 30_000_000);
             if frequency <= 6_000_000 {
                 (6_000_000 / frequency - 1, Some(true))
@@ -80,7 +80,18 @@ mod clock_divisor {
         6_000_001,
         (3, Some(false))
     );
-    pos!(max, DeviceType::FT4232H, 30_000_000, (0, Some(false)));
+    pos!(
+        ft4232h_max,
+        DeviceType::FT4232H,
+        30_000_000,
+        (0, Some(false))
+    );
+    pos!(
+        ft4232ha_max,
+        DeviceType::FT4232HA,
+        30_000_000,
+        (0, Some(false))
+    );
 
     neg!(panic_unknown, DeviceType::Unknown, 1_000);
     neg!(panic_ft232c_min, DeviceType::FT2232C, 91);
@@ -424,7 +435,7 @@ pub trait FtdiMpsse: FtdiCommon {
 }
 
 /// This contains MPSSE commands that are only available on the the FT232H,
-/// FT2232H, and FT4232H devices.
+/// FT2232H, and FT4232H(A) devices.
 ///
 /// For details about the MPSSE read the [FTDI MPSSE Basics].
 ///

--- a/src/types.rs
+++ b/src/types.rs
@@ -237,7 +237,7 @@ pub enum DeviceType {
 impl DeviceType {
     /// Get a device type with a USB product ID.
     ///
-    /// This is not entirely accurate since soem devices share the same PID.
+    /// This is not entirely accurate since some devices share the same PID.
     ///
     /// # Example
     ///
@@ -254,6 +254,8 @@ impl DeviceType {
             Some(DeviceType::FT2232H)
         } else if pid == 0x6011 {
             Some(DeviceType::FT4232H)
+        } else if pid == 0x6048 {
+            Some(DeviceType::FT4232HA)
         } else if pid == 0x6014 {
             Some(DeviceType::FT232H)
         } else if pid == 0x6015 {
@@ -281,6 +283,7 @@ impl From<u32> for DeviceType {
             DEVICE_232R => DeviceType::FT232R,
             DEVICE_2232H => DeviceType::FT2232H,
             DEVICE_4232H => DeviceType::FT4232H,
+            DEVICE_4232HA => DeviceType::FT4232HA,
             DEVICE_232H => DeviceType::FT232H,
             DEVICE_X_SERIES => DeviceType::FT_X_SERIES,
             DEVICE_4222H_0 => DeviceType::FT4222H_0,
@@ -433,7 +436,7 @@ pub enum BitMode {
     Reset = FT_BITMODE_RESET as u8,
     /// Asynchronous bit bang.
     AsyncBitbang = FT_BITMODE_ASYNC_BITBANG as u8,
-    /// MPSSE (FT2232, FT2232H, FT4232H and FT232H devices only)
+    /// MPSSE (FT2232, FT2232H, FT4232H(A) and FT232H devices only)
     Mpsse = FT_BITMODE_MPSSE as u8,
     /// Synchronous Bit Bang
     /// (FT232R, FT245R,FT2232, FT2232H, FT4232H and FT232H devices only)
@@ -606,6 +609,7 @@ pub struct DeviceInfo {
     /// * `0x6001` FT232AM/FT232BM/FT232R
     /// * `0x6010` FT2232C/FT2232D/FT2232H
     /// * `0x6011` FT4232/FT4232H
+    /// * `0x6048` FT4232HA
     /// * `0x6014` FT232H
     /// * `0x6015` FT230X/FT231X/FT234X
     pub product_id: u16,


### PR DESCRIPTION
Fixes a few typos along the way as well. Fixes #76

Note: This does not add EEPROM support as there appears to be some missing types in the ffi crate, perhaps it needs a bump?